### PR TITLE
fix: explicitly set audience for idporten client assertion

### DIFF
--- a/src/auth/middlewares/strategy/idporten.ts
+++ b/src/auth/middlewares/strategy/idporten.ts
@@ -20,7 +20,10 @@ async function idporten(): Promise<Strategy<User, Client>> {
     { keys: [jwk] }
   );
 
-  return new Strategy({ client }, (tokenset, userinfo, done) => {
+  return new Strategy({
+      client: client,
+      extras: { clientAssertionPayload: { aud: issuer.issuer }}
+  }, (tokenset, userinfo, done) => {
     const { locale } = tokenset.claims();
     const user: User = {
       fnr: userinfo.pid,

--- a/src/auth/middlewares/tokenx.ts
+++ b/src/auth/middlewares/tokenx.ts
@@ -22,7 +22,7 @@ export default async function tokenx(
     const additionalClaims = {
       clientAssertionPayload: {
         nbf: now,
-        aud: tokenXClient.issuer.metadata.issuer
+        aud: tokenXClient.issuer.metadata.token_endpoint
       },
     };
 

--- a/src/auth/middlewares/tokenx.ts
+++ b/src/auth/middlewares/tokenx.ts
@@ -22,6 +22,7 @@ export default async function tokenx(
     const additionalClaims = {
       clientAssertionPayload: {
         nbf: now,
+        aud: tokenXClient.issuer.metadata.issuer
       },
     };
 


### PR DESCRIPTION
By default, `openid-client` sets audience for client assertions to be an array of various different endpoints: https://github.com/panva/node-openid-client/blob/e7ded6121f5e42f32fac55a477ed8578719f8561/lib/helpers/client.js#L70-L76

ID-porten expects exact matching on the `aud` claim to only contain the `issuer` endpoint in the metadata document, thus we need to override the default settings from `openid-client`. 