### PR TITLE
Bruk veilarbregistrering i GCP i prod

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -63,8 +63,6 @@ spec:
         - application: safselvbetjening
           namespace: teamdokumenthandtering
           cluster: {{saf.cluster}}
-        - application: pto-proxy
-          namespace: pto
         - application: veilarbregistrering
           namespace: paw
   idporten:

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -5,7 +5,7 @@ dekorator:
   env: prod
 loginservice:
   url: https://loginservice.nav.no/login
-veilarbproxyUrl: http://pto-proxy.pto.svc.cluster.local/proxy/veilarbregistrering
+veilarbproxyUrl: http://veilarbregistrering.paw.svc.cluster.local/veilarbregistrering
 amplitude:
   apiKey: 913768927b84cde5eac0d0d18c737561
 saf:


### PR DESCRIPTION
Fjern også regel som åpner for trafikk til pto-proxy, ser ut til at denne ikke er i bruk lenger nå