### PR TITLE
Fiks bearer token for arbeidssøkers perioder

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [test, build]
-    if: github.ref == 'refs/heads/fiks-bearer-token'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch NAIS yaml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [test, build]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/fiks-bearer-token'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch NAIS yaml

--- a/src/lib/audience.ts
+++ b/src/lib/audience.ts
@@ -1,2 +1,3 @@
 export const innsynAudience = `${process.env.NAIS_CLUSTER_NAME}:teamdagpenger:dp-innsyn`;
 export const safAudience = `${process.env.SAF_SELVBETJENING_CLUSTER}:teamdokumenthandtering:${process.env.SAF_SELVBETJENING_SCOPE}`;
+export const veilarbAudience = `${process.env.NAIS_CLUSTER_NAME}:paw:veilarbregistrering`;

--- a/src/pages/api/arbeidssoker/perioder.ts
+++ b/src/pages/api/arbeidssoker/perioder.ts
@@ -1,75 +1,49 @@
-import { NextApiHandler } from "next";
+import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 import { getSession } from "../../../lib/auth.utils";
 import { v4 as uuid } from "uuid";
-import path from "path";
 import { decodeJwt } from "@navikt/dp-auth";
+import { formatISO } from "date-fns";
 
 export type Arbeidssøkerperiode = {
   fraOgMedDato: string;
   tilOgMedDato: string;
 };
 
-const periodeFormatter = new Intl.DateTimeFormat("no", {
-  year: "numeric",
-  month: "2-digit",
-  day: "2-digit",
-});
-
-function formaterDato(date: Date) {
-  return periodeFormatter.format(date).split(".").reverse().join("-");
-}
-
-export const leggTilQueries = (fnr: string): string => {
-  const idag = new Date();
-  const query = new URLSearchParams();
-  query.append("fnr", fnr);
-  query.append("fraOgMed", formaterDato(idag));
-
-  return `?${query.toString()}`;
-};
-
 const perioderHandler: NextApiHandler<Arbeidssøkerperiode[]> = async (
-  req,
-  res
+  req: NextApiRequest,
+  res: NextApiResponse
 ) => {
-  const session = await getSession(req);
-
-  if (!session.token) return res.status(401).end();
-  const payload = decodeJwt(session.token);
-
   const callId = uuid();
-  const url = new URL(process.env.VEILARBPROXY_URL);
-  url.pathname = path.join(url.pathname, "/api/arbeidssoker/perioder");
-  url.search = leggTilQueries(<string>payload.pid);
-
-  console.log(
-    `Henter arbeidssøkerperioder fra veilarbregistrering (callId: ${callId})`
-  );
 
   try {
-    const { arbeidssokerperioder } = await fetch(url.toString(), {
+    const { token } = await getSession(req);
+
+    if (!token) {
+      return res.status(401).end();
+    }
+
+    const payload = decodeJwt(token);
+    const today = formatISO(new Date(), { representation: "date" });
+    const url = `${process.env.VEILARBPROXY_URL}/api/arbeidssoker/perioder?fnr=${payload?.pid}&fraOgMed=${today}`;
+
+    console.log(
+      `Henter arbeidssøkerperioder fra veilarbregistrering (callId: ${callId})`
+    );
+
+    const response = await fetch(url, {
       headers: {
-        cookie: `selvbetjening-idtoken=${session.token}`,
+        Authorization: `Bearer ${token}`,
+        "Downstream-Authorization": `Bearer ${token}`,
         "Nav-Consumer-Id": "dp-dagpenger",
         "Nav-Call-Id": callId,
       },
-    }).then(async (res) => {
-      const contentType = res.headers.get("content-type");
-      if (!contentType || !contentType.includes("application/json")) {
-        throw new TypeError(
-          `Fikk ikke JSON fra veilarbregistrering (callId ${callId}). Body: ${await res.text()}.`
-        );
-      }
-
-      return res.json();
     });
 
-    console.log(
-      `Svar fra veilarberegistrering (callId: ${callId})`,
-      arbeidssokerperioder
-    );
+    if (!response.ok) {
+      return res.status(response.status).send(response.statusText);
+    }
 
-    return res.json(arbeidssokerperioder);
+    return res.status(response.status).json(response);
   } catch (error) {
     console.error(
       `Kall mot veilarbregistrering (callId: ${callId}) feilet. Feilmelding: ${error}`

--- a/src/pages/api/arbeidssoker/perioder.ts
+++ b/src/pages/api/arbeidssoker/perioder.ts
@@ -44,7 +44,8 @@ const perioderHandler: NextApiHandler<Arbeidssøkerperiode[]> = async (
       return res.status(response.status).send(response.statusText);
     }
 
-    return res.status(response.status).json(response);
+    const perioder = await response.json();
+    return res.status(response.status).json(perioder);
   } catch (error) {
     console.error(
       `Kall mot veilarbregistrering (callId: ${callId}) feilet. Feilmelding: ${error}`


### PR DESCRIPTION
Fra før av brukte vi `cookie: selvbetjening-idtoken=${session.token}` for autentisering, i denne PRen går vi over til å bruke `Authorization: Bearer ${token}` i tillegg til at vi går over til det nye endepunktet som støtter tokenX. Har også omstrukturert endepunktet for å gjøre det likere strukturen på liknende API-endepunkter i søknadsdialogen.