### PR TITLE
Fix/dokument nedlastning

### DIFF
--- a/src/__tests__/api/dokumenter/__snapshots__/forhåndsvisning.test.ts.snap
+++ b/src/__tests__/api/dokumenter/__snapshots__/forhåndsvisning.test.ts.snap
@@ -1,15 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`/api/dokumenter/[journalpostId]/[dokumentId]/forhandsvisning svarer med en liste dokumenter 1`] = `
-Object {
-  "data": Array [
-    98,
-    105,
-    110,
-    195,
-    166,
-    114,
-  ],
-  "type": "Buffer",
-}
-`;
+exports[`/api/dokumenter/[journalpostId]/[dokumentId]/forhandsvisning svarer med en liste dokumenter 1`] = `""`;

--- a/src/pages/api/dokumenter/[journalpostId]/[dokumentId]/forhandsvisning.ts
+++ b/src/pages/api/dokumenter/[journalpostId]/[dokumentId]/forhandsvisning.ts
@@ -35,7 +35,7 @@ export const handleHentDokument: NextApiHandler<Stream> = async (req, res) => {
 
   const { journalpostId, dokumentId } = req.query;
   const callId = uuidv4();
-  hentDokument(
+  return hentDokument(
     await session.apiToken(audience),
     <string>journalpostId,
     <string>dokumentId,

--- a/src/pages/api/dokumenter/[journalpostId]/[dokumentId]/forhandsvisning.ts
+++ b/src/pages/api/dokumenter/[journalpostId]/[dokumentId]/forhandsvisning.ts
@@ -2,22 +2,22 @@ import { NextApiHandler } from "next";
 import { v4 as uuidv4 } from "uuid";
 import { withSentry } from "@sentry/nextjs";
 import { getSession } from "../../../../../lib/auth.utils";
+import { Stream } from "stream";
 
 const audience = `${process.env.SAF_SELVBETJENING_CLUSTER}:teamdokumenthandtering:${process.env.SAF_SELVBETJENING_SCOPE}`;
 
-type Dokument = {
-  headers: {
-    contentDisposition: string;
-  };
-  blob: Blob;
+export const config = {
+  api: {
+    responseLimit: false,
+  },
 };
 
 async function hentDokument(
   token: string,
   journalpostId: string,
-  dokumentInfoId: string
-): Promise<Dokument> {
-  const callId = uuidv4();
+  dokumentInfoId: string,
+  callId: uuidv4
+): Promise<Response> {
   const endpoint = `${process.env.SAF_SELVBETJENING_INGRESS}/rest/hentdokument/${journalpostId}/${dokumentInfoId}/ARKIV`;
 
   const headers = {
@@ -26,47 +26,40 @@ async function hentDokument(
     "Nav-Consumer-Id": "dp-dagpenger",
   };
 
-  try {
-    console.log(`Henter dokument med call-id: ${callId}`);
-    return await fetch(endpoint, { headers }).then(async (res) => {
-      const headers = {
-        contentDisposition: res.headers.get("Content-Disposition"),
-      };
-
-      return { headers, blob: await res.blob() };
-    });
-  } catch (error) {
-    console.error(`Feil fra SAF med call-id ${callId}: ${error}`);
-    throw error;
-  }
+  return fetch(endpoint, { headers });
 }
 
-export const handleHentDokument: NextApiHandler<Buffer> = async (req, res) => {
+export const handleHentDokument: NextApiHandler<Stream> = async (req, res) => {
   const session = await getSession(req);
   if (!session.token) return res.status(401).end();
 
   const { journalpostId, dokumentId } = req.query;
-
-  try {
-    const { blob: dokument, headers } = await hentDokument(
-      await session.apiToken(audience),
-      <string>journalpostId,
-      <string>dokumentId
-    );
-
-    console.log(`Fått dokument, størrelse: ${dokument.size}`);
-
-    res.setHeader(
-      "Content-Disposition",
-      headers.contentDisposition || "inline"
-    );
-    res.setHeader("Content-Type", dokument.type);
-    const buffer = Buffer.from(new Uint8Array(await dokument.arrayBuffer()));
-
-    return res.send(buffer);
-  } catch (errors) {
-    return res.status(500).send(errors);
-  }
+  const callId = uuidv4();
+  hentDokument(
+    await session.apiToken(audience),
+    <string>journalpostId,
+    <string>dokumentId,
+    callId
+  )
+    .then(async (dokumentResponse) => {
+      res.setHeader(
+        "Content-Disposition",
+        dokumentResponse.headers.get("Content-Disposition") || "inline"
+      );
+      return dokumentResponse.blob();
+    })
+    .then((blob) => {
+      return new Promise((resolve) => {
+        res.setHeader("Content-Type", blob.type);
+        const stream = blob.stream() as unknown as NodeJS.ReadableStream;
+        stream.pipe(res);
+        stream.on("end", resolve);
+      });
+    })
+    .catch((errors) => {
+      console.error(`Feil fra SAF med call-id ${callId}: ${errors}`);
+      return res.status(500).send(errors);
+    });
 };
 
 export default withSentry(handleHentDokument);


### PR DESCRIPTION
Appen kræsjet når en prøvde å laste ned/forhåndsvise store file (> 50 mb). Fikset det ved å ikke lese inn hele fila i en blob og buffer - men streame det videre. 

Lurer på om vi skal ha en "vente signal", men tror det holder. 

https://user-images.githubusercontent.com/219278/224643495-b78935d7-ce78-4b85-a1c9-30ce0fef7db2.mov

