### PR TITLE
Access policy for eksterne URLer

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -69,6 +69,8 @@ spec:
         - host: rt6o382n.apicdn.sanity.io
         - host: www.nav.no
         - host: dekoratoren.dev.nav.no
+        - host: unleash.nais.io
+        - host: amplitude.nav.no
       rules:
         - application: dp-innsyn
         - application: safselvbetjening

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -71,6 +71,7 @@ spec:
         - host: dekoratoren.dev.nav.no
         - host: unleash.nais.io
         - host: amplitude.nav.no
+        - host: 98d1497555654049a7d46e29a5208e61@sentry.gc.nav.no
       rules:
         - application: dp-innsyn
         - application: safselvbetjening

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -62,6 +62,13 @@ spec:
     outbound:
       external:
         - host: {{saf.ingress}}
+        - host: api.sanity.io
+        - host: apicdn.sanity.io
+        - host: cdn.sanity.io
+        - host: rt6o382n.api.sanity.io
+        - host: rt6o382n.apicdn.sanity.io
+        - host: www.nav.no
+        - host: dekoratoren.dev.nav.no
       rules:
         - application: dp-innsyn
         - application: safselvbetjening


### PR DESCRIPTION
Har lagt til:
- Sanity
- Sentry
- Unleash
- Amplitude
- NAV-dekoratøren

Unleash ligger kun her siden den ikke brukes i søknadsdialogen.